### PR TITLE
renovate.json: Just inherit default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>platform-engineering-org/.github"
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION
Inheriting from platform-engineering is breaking things, cc https://github.com/bootc-dev/infra/issues/19