### PR TITLE
renovate.json: Remove platform-engineering-org inheritance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>platform-engineering-org/.github"
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION
This removes the inheritance from platform-engineering-org/.github to fix the 'Edited' warning that prevents Renovate from automatically rebasing PRs.

The warning occurs because Renovate doesn't recognize bootc-bot as a valid commit author when it's configured through the inherited configuration.

See https://github.com/bootc-dev/infra/issues/19 for context.

This is part of a batch update across all bootc-dev repositories.